### PR TITLE
Blocking gmail

### DIFF
--- a/trackers.txt
+++ b/trackers.txt
@@ -189,7 +189,6 @@ i.mail.ru
 ibm.com
 in.hotjar.com
 inboundwriter.com
-inbox.google.com
 infinito.email
 infinitummail.com
 infonline.de

--- a/trackers.txt
+++ b/trackers.txt
@@ -82,7 +82,6 @@ cmail20.com
 cmcore.com
 cnode.io
 cnzz.com
-code.highcharts.com
 collserve.com
 commsvc.geo.de
 compete.com
@@ -163,14 +162,12 @@ getsitecontrol.com
 gfk.com
 gfkdaphne.com
 glanceguide.com
-gmail.com
 go-mpulse.net
 godaddy.com
 gomez.com
 google-analytics.com
 googleadapis.l.google.com
 googleadservices.com
-googlemail.com
 googlesyndication.com
 googletagmanager.com
 googletagservices.com
@@ -224,7 +221,6 @@ lynchpin.com
 lypn.com
 lyris.com
 lytiks.com
-mail.google.com
 mandrill.com
 mandrillapp.com
 marinsm.com


### PR DESCRIPTION
Hi, you are blocking all the Gmail domains.
gmail.com
mail.google.com
googlemail.com
inbox.google.com
Additionally, code.highcharts.com is not a tracker. It is Javascript code for HTML5 charting.

Can you please open Issues so I can submit issues without needing to make a pull request?

Thanks
@herrbischoff 